### PR TITLE
Stop running the DHT after we have enough peers

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,6 +88,9 @@ var Swarm = function(infoHash, options, onconnection) {
 
 		if (nodes) parseNodeInfo(nodes).forEach(node);
 		if (values) parsePeerInfo(values).forEach(peer);
+	
+		if (Object.keys(self._visitedPeers).length > self.maxSize*2)
+			self._sock.close();
 	});
 
 	if (onconnection) this.on('connection', onconnection);


### PR DESCRIPTION
Stop running the DHT if the peer count reaches two times the limit. This saves network bandwidth at the beginning of the stream, while still allowing for enough peers for swapping.

Not completely sure about the benefits, should be quite beneficial in theory, and it feels like it in practice.
