### PR TITLE
js strict mode and handshake options

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,3 @@
-(function() {
-"use strict";
-
-
-
 var net = require('net');
 var fifo = require('fifo');
 var once = require('once');
@@ -111,7 +106,7 @@ var Swarm = function(infoHash, peerId, options) {
 	EventEmitter.call(this);
 
 	options = options || {};
-	this.handshake_options = options.handshake_options;
+	this.handshake = options.handshake;
 
 	this.port = 0;
 	this.size = options.size || DEFAULT_SIZE;
@@ -261,7 +256,7 @@ Swarm.prototype._drain = function() {
 	self._onconnection(connection);
 
 	wire.peerAddress = addr;
-	wire.handshake(this.infoHash, this.peerId, this.handshake_options);
+	wire.handshake(this.infoHash, this.peerId, this.handshake);
 };
 
 Swarm.prototype._shift = function() {
@@ -273,7 +268,7 @@ Swarm.prototype._shift = function() {
 
 Swarm.prototype._onincoming = function(connection, wire) {
 	wire.peerAddress = connection.address().address + ':' + connection.address().port;
-	wire.handshake(this.infoHash, this.peerId, this.handshake_options);
+	wire.handshake(this.infoHash, this.peerId, this.handshake);
 
 	this._onconnection(connection);
 	this._onwire(connection, wire);
@@ -322,5 +317,3 @@ Swarm.prototype._onwire = function(connection, wire) {
 };
 
 module.exports = Swarm;
-
-})();


### PR DESCRIPTION
This changes allow to pass handshake options from swarm "user" (usualy peerflix engine) through swarm api to wire instance (peer)

Also code was switched to strict mode
