### PR TITLE
Increment HANDSHAKE_TIMEOUT

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var peerWireProtocol = require('peer-wire-protocol');
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 
-var HANDSHAKE_TIMEOUT = 5000;
+var HANDSHAKE_TIMEOUT = 25000;
 var RECONNECT_WAIT = [1000, 5000, 15000, 30000, 60000, 120000, 300000, 600000];
 var DEFAULT_SIZE = 100;
 


### PR DESCRIPTION
Needed to solve https://github.com/mafintosh/torrent-stream/issues/14

Not flooding the connection with UDP packets improved a lot the performance, but incrementing the HANDSHAKE_TIMEOUTS also improves the number of peers.
