### PR TITLE
More aggressive reconnect_wait

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var util = require('util');
 
 var HANDSHAKE_TIMEOUT = 25000;
 var CONNECTION_TIMEOUT = 3000;
-var RECONNECT_WAIT = [1000, 5000, 15000, 30000, 60000, 120000, 300000, 600000];
+var RECONNECT_WAIT = [1000, 5000, 15000];
 var DEFAULT_SIZE = 100;
 
 var toBuffer = function(str, encoding) {


### PR DESCRIPTION
A reconnect wait like this is very negative behaviour - it leads to peers which are un-available being tried over and over again, taking up slots for new connections.

It's pretty safe to assume that if a peer fails the re-connect three times, it's not going to succeed in general. Better try new connections than keep re-trying.