### PR TITLE
Fixes Reconnecting to Wires

### DIFF
--- a/index.js
+++ b/index.js
@@ -243,7 +243,7 @@ Swarm.prototype.destroy = function() {
 Swarm.prototype.reconnectAll = function() {
 	var self = this;
 	Object.keys(this._peers).forEach(function(addr) {
-		var isConnected = self.wires.some(function (e) { if (e.peerAddress == addr) return true; });
+		var isConnected = self.wires.some(function (e) { return e.peerAddress === addr; });
  		if (!isConnected) {
  			self._remove(addr);
  			self.add(addr);

--- a/index.js
+++ b/index.js
@@ -174,6 +174,7 @@ Swarm.prototype.pause = function() {
 };
 
 Swarm.prototype.resume = function() {
+	if (this.paused) this.reconnectAll();
 	this.paused = false;
 	this._drain();
 };
@@ -236,6 +237,18 @@ Swarm.prototype.destroy = function() {
 	leave(this.port, this);
 	process.nextTick(function() {
 		self.emit('close');
+	});
+};
+
+Swarm.prototype.reconnectAll = function() {
+	var self = this;
+	Object.keys(this._peers).forEach(function(addr) {
+		var shouldReconnect = true;
+		for (var i = 0; self.wires[i]; i++) if (self.wires[i].peerAddress == addr) { shouldReconnect = false; break; }
+		if (shouldReconnect) {
+			self._remove(addr);
+			self.add(addr);
+		}
 	});
 };
 

--- a/index.js
+++ b/index.js
@@ -243,10 +243,10 @@ Swarm.prototype.destroy = function() {
 Swarm.prototype.reconnectAll = function() {
 	var self = this;
 	Object.keys(this._peers).forEach(function(addr) {
-		var shouldReconnect = self.wires.some(function (e) { if (e.peerAddress == addr) return true; });
-		if (shouldReconnect) {
-			self._remove(addr);
-			self.add(addr);
+		var isConnected = self.wires.some(function (e) { if (e.peerAddress == addr) return true; });
+ 		if (!isConnected) {
+ 			self._remove(addr);
+ 			self.add(addr);
 		}
 	});
 };

--- a/index.js
+++ b/index.js
@@ -243,8 +243,7 @@ Swarm.prototype.destroy = function() {
 Swarm.prototype.reconnectAll = function() {
 	var self = this;
 	Object.keys(this._peers).forEach(function(addr) {
-		var shouldReconnect = true;
-		for (var i = 0; self.wires[i]; i++) if (self.wires[i].peerAddress == addr) { shouldReconnect = false; break; }
+		var shouldReconnect = self.wires.some(function (e) { if (e.peerAddress == addr) return true; });
 		if (shouldReconnect) {
 			self._remove(addr);
 			self.add(addr);


### PR DESCRIPTION
As mentioned on https://github.com/mafintosh/peerflix/issues/203

Fixes reconnecting to wires in `swarm.resume()` and adds the `swarm.reconnectAll()` method.
