### PR TITLE
Use wire 'close' instead of wire 'end'

### DIFF
--- a/index.js
+++ b/index.js
@@ -290,7 +290,7 @@ Swarm.prototype._drain = function() {
 		self._onwire(connection, wire);
 	});
 
-	wire.on('end', function() {
+	wire.on('close', function() {
 		peer.wire = null;
 		if (!peer.reconnect || self._destroyed || peer.retries >= RECONNECT_WAIT.length) return self._remove(addr);
 		peer.timeout = setTimeout(repush, RECONNECT_WAIT[peer.retries++]);


### PR DESCRIPTION
It seems that when a connection dies, 'close' gets emitted every time while 'end' for some reason doesn't. I looked at things and I think 'end' won't get emitted if the connection is never opened, so 'close' makes more sense.

With 'end' we get a lot of peers which are stuck indefinitely in _peers, and we don't try reconnecting and we can't even re-add them to the swarm.

Just close this if it's chosen deliberately over 'close', just explain it in a comment.