### PR TITLE
destroy all wires when swarm is destroyed

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,6 +233,10 @@ Swarm.prototype.destroy = function() {
 		self._remove(addr);
 	});
 
+	this.wires.forEach(function (wire) {
+		wire.destroy();
+	});
+
 	leave(this.port, this);
 	process.nextTick(function() {
 		self.emit('close');


### PR DESCRIPTION
The `destroy` call destroys wires for peers that we connected to, but not peers that initiated the connection to us, creating a possible memory leak in torrent-stream. torrent-stream keeps around wires that choked us unless `(swarm.queued > 2 * (swarm.size - swarm.wires.length) && wire.amInterested)`, which doesn't seem to happen once the engine is destroyed.